### PR TITLE
Board: NoTask-Element mit Status-Text und richtigem Großbuchstaben

### DIFF
--- a/scripts/templates.js
+++ b/scripts/templates.js
@@ -92,7 +92,7 @@ function getSubtaskProgressTemplate(done, total) {
 
 function getNoTasksTemplate(status) {
   return `
-    <li class="board-task no-task">No tasks ${status}</li>
+    <li class="board-task no-task">No tasks ${capitalizeFirstLetter(status)}</li>
   `;
 }
 


### PR DESCRIPTION
Fixes #20 Hinzufügen der bereits erstellten Capitalized First Letter Funktion. Somit wird immer der erste Buchstabe großgeschrieben, bei den no tasks.