### PR TITLE
Status übernahme

### DIFF
--- a/scripts/board-dialog.js
+++ b/scripts/board-dialog.js
@@ -96,7 +96,7 @@ function closeDialogOnBackdropClick(event) {
 }
 
 function addStatusTask(status) {
-  openAddTaskDialog();
+  openAddTaskDialog(status);
   console.log(status);
 }
 


### PR DESCRIPTION
fix: pass status parameter to openAddTaskDialog in addStatusTask function

Die Add Tasks in der jeweiligen Status-Tabelle werden jetzt richtig übernommen und die Task wird dort gerendert, in der jeweiligen Status, wo sie auch erstellt wird. 