### PR TITLE
Lehnerma/issue52

### DIFF
--- a/html/board.html
+++ b/html/board.html
@@ -19,7 +19,7 @@
     <link rel="stylesheet" href="../styles/subtasks.css" />
 
     <script src="../scripts/templates.js"></script>
-
+    <script src="../scripts/addTask.js"></script>
     <script src="../scripts/board.js"></script>
     <script src="../scripts/utilitys.js"></script>
     <script src="../scripts/board-move-task.js"></script>

--- a/html/board.html
+++ b/html/board.html
@@ -118,9 +118,7 @@
         <section class="kanban-column" ondragover="columnDragOver(event, 'done')" ondrop="taskDragDrop('done')" ondragleave="columnDragLeave(event)">
           <div class="column-title">
             <h2>Done</h2>
-            <button class="btn btn--add-task" aria-label="Add task to Done" onclick="addStatusTask('done')">
-              <img src="../assets/img/icons/subtask/add.svg" alt="" aria-hidden="true" />
-            </button>
+
           </div>
           <ul class="task--list" id="done_list"></ul>
         </section>

--- a/scripts/board-dialog.js
+++ b/scripts/board-dialog.js
@@ -124,7 +124,7 @@ function openTaskDetailDialog(taskId) {
     CURRENT_DETAIL_TASK = TASK;
     TASK_DETAIL_DIALOG.innerHTML = buildTaskDetailDialog(TASK);
     TASK_DETAIL_DIALOG.showModal();
-    TASK_DETAIL_DIALOG.scrollTop = 0; // Scrollt zum Anfang des Dialogs
+    TASK_DETAIL_DIALOG.querySelector(".detail-task--content").scrollTop = 0;
   }
 }
 
@@ -307,7 +307,7 @@ function refreshTaskDetailDialog(taskId) {
   if (TASK) {
     CURRENT_DETAIL_TASK = TASK;
     TASK_DETAIL_DIALOG.innerHTML = buildTaskDetailDialog(TASK);
-    TASK_DETAIL_DIALOG.scrollTop = 0;
+    TASK_DETAIL_DIALOG.querySelector(".detail-task--content").scrollTop = 0;
   }
 }
 

--- a/scripts/board-dialog.js
+++ b/scripts/board-dialog.js
@@ -179,15 +179,14 @@ function buildTaskDetailDialog(task) {
 
 /**
  * Starts the edit process.
- * It finds the task data, closes the detail view, and opens the edit window.
+ * Opens the edit dialog on top of the detail view — no slide animation.
  *
  * @param {string} taskId - The ID of the task to be edited.
  */
-async function openEditTaskDialog(taskId) {
+function openEditTaskDialog(taskId) {
   const ALL_TASKS = JSON.parse(sessionStorage.tasks);
   const task = ALL_TASKS.find((t) => t.id === taskId);
   if (!task) return;
-  await closeTaskDetailDialog();
   const dialog = document.getElementById("edit_task_dialog");
   dialog.addEventListener("click", closeEditDialogOnBackdropClick);
   dialog.showModal();
@@ -233,13 +232,12 @@ function setupEditTaskInteractions(task) {
 }
 
 /**
- * Closes the edit task window with a slide-out animation.
- *
- * @returns {Promise} A promise that finishes when the animation is done.
+ * Closes the edit task dialog instantly (no animation).
+ * The detail dialog remains open underneath.
  */
 function closeEditTaskDialog() {
   const dialog = document.getElementById("edit_task_dialog");
-  return slideOutDialog(dialog);
+  dialog.close();
 }
 
 /**
@@ -293,8 +291,24 @@ async function saveEditedTask(task) {
   await updateTaskData(updated);
   const ALL_TASKS = JSON.parse(sessionStorage.tasks);
   renderBoard(ALL_TASKS);
-  await closeEditTaskDialog();
-  openTaskDetailDialog(updated.id);
+  closeEditTaskDialog();
+  refreshTaskDetailDialog(updated.id);
+}
+
+/**
+ * Refreshes the detail dialog content in-place without reopening it.
+ *
+ * @param {string} taskId - The ID of the task to refresh.
+ */
+function refreshTaskDetailDialog(taskId) {
+  const TASK_DETAIL_DIALOG = document.getElementById("task_detail_dialog");
+  const ALL_TASKS = JSON.parse(sessionStorage.tasks);
+  const TASK = ALL_TASKS.find((task) => task.id === taskId);
+  if (TASK) {
+    CURRENT_DETAIL_TASK = TASK;
+    TASK_DETAIL_DIALOG.innerHTML = buildTaskDetailDialog(TASK);
+    TASK_DETAIL_DIALOG.scrollTop = 0;
+  }
 }
 
 /**

--- a/scripts/templates.js
+++ b/scripts/templates.js
@@ -179,7 +179,7 @@ function getDetailTaskTemplate(task) {
       </section>
 
       <section class="detail-task--subtasks">
-        <h4>Subtasks</h4>
+        <h4 class="detail-task--subheading">Subtasks</h4>
         <ul id="detail_subtask_list" class="detail-task--subtasks-list" aria-label="list of subtasks">
 
         </ul>
@@ -204,7 +204,7 @@ function getDetailSubtaskTemplate(title, checked = false, id) {
   return `
     <li class="detail-task--subtask-item f-row">
       <input type="checkbox" id="sub_check${id}" class="detail-task--subtask-checkbox"${checked ? " checked" : ""} />
-      <label for="sub_check${id}" class="detail-task--subtask-text">${title}</label>
+      <p for="sub_check${id}" class="detail-task--subtask-text">${title}</p>
     </li>`;
 }
 

--- a/scripts/templates.js
+++ b/scripts/templates.js
@@ -153,7 +153,7 @@ function getDetailTaskTemplate(task) {
       <h2 class="detail-task--title">${task.title}</h2>
     </header>
 
-    <article class="detail-task--content f-col" aria-label="detailed information of the task">
+    <article class="detail-task--content" aria-label="detailed information of the task">
 
       <div class="detail-task--description detail-task--text">${task.description}</div>
 

--- a/style.css
+++ b/style.css
@@ -86,7 +86,7 @@
   width: 32px;
   height: 32px;
   background-color: transparent;
-
+  border-radius: 50%;
   &:hover {
     background-color: var(--btn-arrow-hover);
     border-radius: 50%;

--- a/styles/board-dialog.css
+++ b/styles/board-dialog.css
@@ -103,13 +103,13 @@
         width: 42px;
         height: 42px;
       }
-
-      .assignee--name {
-        font-family: "Open Sans", sans-serif;
-        font-size: 19px;
-      }
     }
   }
+}
+
+.assignee--name {
+  font-family: "Open Sans", sans-serif;
+  font-size: 19px;
 }
 
 .detail-task--subtask-item {
@@ -119,9 +119,6 @@
   padding: 8px 16px;
   width: auto;
 }
-
-
-
 
 .detail-task--header,
 .detail-task--content,
@@ -273,4 +270,16 @@
   font-size: 16px;
   font-weight: 400;
   margin: 0;
+}
+
+@media (max-width: 900px) {
+  .detail-task--title {
+    font-size: 36px;
+  }
+  .detail-task--description,
+  .detail-task--subheading,
+  .detail-task--text,
+  .assignee--name {
+    font-size: 16px;
+  }
 }

--- a/styles/board-dialog.css
+++ b/styles/board-dialog.css
@@ -44,6 +44,7 @@
   width: clamp(310px, calc(228.571px + 25.446vw), 595px);
   max-width: 525px;
   max-height: 95vh;
+  overflow-y: hidden;
 }
 
 .dialog .slide-in {
@@ -57,7 +58,7 @@
 .dialog::backdrop {
   background-color: rgba(0, 0, 0, 0.4);
 }
-.detail-task--header{
+.detail-task--header {
   padding: 8px;
 }
 .detail-task--category {
@@ -84,7 +85,12 @@
 }
 
 .detail-task--content {
+  display: flex;
+  flex-direction: column;
   margin: 24px 0;
+  overflow-y: auto;
+  max-height: 70dvh;
+  height: 100%;
 }
 
 .detail-task--prio-content {
@@ -274,6 +280,9 @@
 @media (max-width: 900px) {
   .detail-task--title {
     font-size: 36px;
+  }
+  .detail-task--subheading{
+    color: var(--board-title-col);
   }
   .detail-task--description,
   .detail-task--subheading,

--- a/styles/board-dialog.css
+++ b/styles/board-dialog.css
@@ -57,7 +57,9 @@
 .dialog::backdrop {
   background-color: rgba(0, 0, 0, 0.4);
 }
-
+.detail-task--header{
+  padding: 8px;
+}
 .detail-task--category {
   display: flex;
   align-items: center;
@@ -113,11 +115,8 @@
 }
 
 .detail-task--subtask-item {
-  display: flex;
-  align-items: center;
   gap: 16px;
   padding: 8px 16px;
-  width: auto;
 }
 
 .detail-task--header,
@@ -133,21 +132,20 @@
   height: 24px;
   cursor: pointer;
   appearance: none;
-  background-size: 24px 24px;
   background-repeat: no-repeat;
   background-position: center;
+  object-fit: contain;
   border: none;
-  padding: 0;
 
   &:hover {
     background-color: var(--input-default-main);
     border-radius: 50%;
-    transform: scale(1.05);
   }
 }
 
-.detail-task--subtask-text:hover {
-  transform: scale(1.05);
+.detail-task--subtask-text {
+  width: 100%;
+  max-width: 320px;
 }
 
 .detail-task--subtask-checkbox:not(:checked) {
@@ -161,6 +159,7 @@
 .detail-task--footer {
   justify-content: flex-end;
   gap: 8px;
+  padding: 8px;
 }
 
 .btn--delete,

--- a/styles/board.css
+++ b/styles/board.css
@@ -416,7 +416,8 @@
 
 .drag-placeholder {
   min-height: 80px;
-  width: 252px;
+  min-width: 220px;
+  min-width: 252px;
   border: 2px dashed #a8a8a8;
   border-radius: 24px;
   background: transparent;


### PR DESCRIPTION
Komplett überarbeiten der Detail-Task-Einsicht, Plus-Tuschen des Dialogs, Weiterleitung an die Add-Task-Seite. Neue Logikimplementierung für setzende Status, sodass auch auf bestimmten Status-Tabelle Add-Task gedrückt wird, die dann auch übernommen wird. Zusätzlich wird das über den Session Storage gelöst. Der wird aber wieder sofort empfangen, sobald du auf die Add-Task-Seite kommst.

Wenn eine normale Task erstellt werden sollte, kann eine dealerhafte Status übernommen werden. Somit sollte auch das Problem gelöst sein von den doppelten Task-Einträgen. 