### PR TITLE
#98 Changing the Title of Legal Notice

### DIFF
--- a/html/legalNotice.html
+++ b/html/legalNotice.html
@@ -1,168 +1,138 @@
 <!doctype html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/x-icon" href="/assets/img/favicon/favicon-join.svg" />
+    <title>Legal Notice</title>
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="icon" type="image/x-icon" href="/assets/img/favicon/favicon-join.svg" />
-  <title>Legal Notice</title>
+    <script src="../scripts/utilitys.js"></script>
 
-  <script src="../scripts/utilitys.js"></script>
+    <link rel="stylesheet" href="../style.css" />
+    <link rel="stylesheet" href="../styles/utility.css" />
+    <link rel="stylesheet" href="../styles/colors.css" />
+    <link rel="stylesheet" href="../styles/sidebar.css" />
+  </head>
 
-  <link rel="stylesheet" href="../style.css" />
-  <link rel="stylesheet" href="../styles/utility.css" />
-  <link rel="stylesheet" href="../styles/colors.css" />
-  <link rel="stylesheet" href="../styles/sidebar.css" />
-</head>
-
-<body class="app user-not-logged-in" onload="initUtilitys()">
-  <div class="landscape-warning">
-    <div class="warning-message">
-      <div class="phone-icon"></div>
-      <p>Use portrait mode.</p>
-    </div>
-  </div>
-  <header class="app--title">
-    <div class="app--title-wrapper">
-      <h1 class="app--title-headline">Kanban Project Management Tool</h1>
-      <img src="../assets/img/logo-join-dark.svg" alt="join logo" class="title-logo" />
-      <div class="app--icons">
-        <a href="./help.html"><img src="../assets/img/icons/general/help.svg" alt="help" class="app--icon" /></a>
-        <button id="user_menu_button" class="btn btn--user" onclick="openUserMenu()"></button>
+  <body class="app user-not-logged-in" onload="initUtilitys()">
+    <div class="landscape-warning">
+      <div class="warning-message">
+        <div class="phone-icon"></div>
+        <p>Use portrait mode.</p>
       </div>
     </div>
-  </header>
+    <header class="app--title">
+      <div class="app--title-wrapper">
+        <h1 class="app--title-headline">Kanban Project Management Tool</h1>
+        <img src="../assets/img/logo-join-dark.svg" alt="join logo" class="title-logo" />
+        <div class="app--icons">
+          <a href="./help.html"><img src="../assets/img/icons/general/help.svg" alt="help" class="app--icon" /></a>
+          <button id="user_menu_button" class="btn btn--user" onclick="openUserMenu()"></button>
+        </div>
+      </div>
+    </header>
 
-  <dialog id="user-menu-dialog" onclick="closeDialog()">
-    <div class="user-menu" onclick="preventCloseDialogOnDialog(event)">
-      <a href="../html/help.html" class="user-menu-help user-menu-link">Help</a>
-      <a href="../html/legalNotice.html" class="user-menu-link">Legal Notice</a>
-      <a href="../html/privacyPolicy.html" class="user-menu-link">Privacy Policy</a>
-      <a href="#" class="user-menu-link" onclick="logOut()">Log out</a>
-    </div>
-  </dialog>
+    <dialog id="user-menu-dialog" onclick="closeDialog()">
+      <div class="user-menu" onclick="preventCloseDialogOnDialog(event)">
+        <a href="../html/help.html" class="user-menu-help user-menu-link">Help</a>
+        <a href="../html/legalNotice.html" class="user-menu-link">Legal Notice</a>
+        <a href="../html/privacyPolicy.html" class="user-menu-link">Privacy Policy</a>
+        <a href="#" class="user-menu-link" onclick="logOut()">Log out</a>
+      </div>
+    </dialog>
 
-  <nav class="sidebar">
-    <img class="nav-logo" src="../assets/img/logo-join.svg" alt="join_logo" />
-    <ul id="view-user">
-      <li class="">
-        <a class="nav-category" href="./summary.html"><img class="nav-category-img"
-            src="../assets/img/icons/general/summary.svg" alt="" />Summary</a>
-      </li>
-      <li class="">
-        <a class="nav-category" href="./addTaskPage.html"><img class="nav-category-img"
-            src="../assets/img/icons/general/add-task.svg" alt="" />Add Task</a>
-      </li>
-      <li class="">
-        <a class="nav-category" href="./board.html"><img class="nav-category-img"
-            src="../assets/img/icons/general/board.svg" alt="" />Board</a>
-      </li>
-      <li class="">
-        <a class="nav-category" href="./contacts.html"><img class="nav-category-img"
-            src="../assets/img/icons/general/contacts.svg" alt="" /> Contacts</a>
-      </li>
-    </ul>
+    <nav class="sidebar">
+      <img class="nav-logo" src="../assets/img/logo-join.svg" alt="join_logo" />
+      <ul id="view-user">
+        <li class="">
+          <a class="nav-category" href="./summary.html"><img class="nav-category-img" src="../assets/img/icons/general/summary.svg" alt="" />Summary</a>
+        </li>
+        <li class="">
+          <a class="nav-category" href="./addTaskPage.html"><img class="nav-category-img" src="../assets/img/icons/general/add-task.svg" alt="" />Add Task</a>
+        </li>
+        <li class="">
+          <a class="nav-category" href="./board.html"><img class="nav-category-img" src="../assets/img/icons/general/board.svg" alt="" />Board</a>
+        </li>
+        <li class="">
+          <a class="nav-category" href="./contacts.html"><img class="nav-category-img" src="../assets/img/icons/general/contacts.svg" alt="" /> Contacts</a>
+        </li>
+      </ul>
 
-    <ul id="view-external">
-      <li class="">
-        <a class="nav-category" href="../index.html"><img class="nav-category-img"
-            src="../assets/img/icons/general/login.svg" alt="" />Log In</a>
-      </li>
-    </ul>
+      <ul id="view-external">
+        <li class="">
+          <a class="nav-category" href="../index.html"><img class="nav-category-img" src="../assets/img/icons/general/login.svg" alt="" />Log In</a>
+        </li>
+      </ul>
 
-    <div class="legal-section">
-      <a class="legal-section-link" href="../html/privacyPolicy.html">Privacy Policy</a>
-      <a class="legal-section-link active" href="../html/legalNotice.html">Legal Notice</a>
-    </div>
-  </nav>
+      <div class="legal-section">
+        <a class="legal-section-link" href="../html/privacyPolicy.html">Privacy Policy</a>
+        <a class="legal-section-link active" href="../html/legalNotice.html">Legal Notice</a>
+      </div>
+    </nav>
 
-  <main class="app--content">
-    <section class="utility-content">
-      <h1 class="utility-h1">Impressum</h1>
-      <br />
+    <main class="app--content">
+      <section class="utility-content">
+        <h2 class="utility-h1">Legal Notice</h2>
+        <br />
 
-      <p>
-        Maximilian Lehner<br />
-        Sportplatzstraße 6<br />
-        AT-3492 Etsdorf
-      </p>
-      <br />
+        <p>
+          Maximilian Lehner<br />
+          Sportplatzstraße 6<br />
+          AT-3492 Etsdorf
+        </p>
+        <br />
 
-      <h2 class="utility-h2">Vertreten durch:</h2>
-      <p>
-        Maximilian Lehner<br />
-        Monika Weikum<br />
-        Nick Ezenwa<br />
-        Radek Gnych<br />
-      </p>
-      <h2 class="utility-h2">Kontakt</h2>
-      <p>
-        Telefon: +43 (0) 6765 212165<br />
-        E-Mail: Max@lm-lehner.at
-      </p>
+        <h2 class="utility-h2">Vertreten durch:</h2>
+        <p>
+          Maximilian Lehner<br />
+          Monika Weikum<br />
+          Nick Ezenwa<br />
+          Radek Gnych<br />
+        </p>
+        <h2 class="utility-h2">Kontakt</h2>
+        <p>
+          Telefon: +43 (0) 6765 212165<br />
+          E-Mail: Max@lm-lehner.at
+        </p>
 
-      <h3 class="utility-h3">Acceptance of terms</h3>
-      <p>By accessing and using <span class="utility-highlighted">Join</span> (Product), you acknowledge and agree to
-        the following terms and conditions, and any policies, guidelines, or amendments thereto that may be presented to
-        you from time to time. We, the listed students, may update or change the terms and conditions from time to time
-        without notice.</p>
+        <h3 class="utility-h3">Acceptance of terms</h3>
+        <p>By accessing and using <span class="utility-highlighted">Join</span> (Product), you acknowledge and agree to the following terms and conditions, and any policies, guidelines, or amendments thereto that may be presented to you from time to time. We, the listed students, may update or change the terms and conditions from time to time without notice.</p>
 
-      <h3 class="utility-h3">Scope and ownership of the product</h3>
-      <p>
-        <span class="utility-highlighted">Join</span> has been developed as part of a student group project in a web
-        development bootcamp at the <span class="utility-highlighted">Developer Akademie GmbH</span>. It has an
-        educational purpose and is not intended for extensive personal & business usage. As such, we cannot guarantee
-        consistent availability, reliability, accuracy, or any other aspect
-        of quality regarding this Product.
-      </p>
-      <p>The design of <span class="utility-highlighted">Join</span> is owned by the <span
-          class="utility-highlighted">Developer Akademie GmbH</span>. Unauthorized use, reproduction, modification,
-        distribution, or replication of the design is strictly prohibited.</p>
+        <h3 class="utility-h3">Scope and ownership of the product</h3>
+        <p>
+          <span class="utility-highlighted">Join</span> has been developed as part of a student group project in a web development bootcamp at the <span class="utility-highlighted">Developer Akademie GmbH</span>. It has an educational purpose and is not intended for extensive personal & business usage. As such, we cannot guarantee consistent availability, reliability, accuracy, or any other aspect
+          of quality regarding this Product.
+        </p>
+        <p>The design of <span class="utility-highlighted">Join</span> is owned by the <span class="utility-highlighted">Developer Akademie GmbH</span>. Unauthorized use, reproduction, modification, distribution, or replication of the design is strictly prohibited.</p>
 
-      <h3 class="utility-h3">Proprietary rights</h3>
-      <p>Aside from the design owned by <span class="utility-highlighted">Developer Akademie GmbH</span>, we, the listed
-        students, retain all proprietary rights in <span class="utility-highlighted">Join</span>, including any
-        associated copyrighted material, trademarks, and other proprietary information.</p>
+        <h3 class="utility-h3">Proprietary rights</h3>
+        <p>Aside from the design owned by <span class="utility-highlighted">Developer Akademie GmbH</span>, we, the listed students, retain all proprietary rights in <span class="utility-highlighted">Join</span>, including any associated copyrighted material, trademarks, and other proprietary information.</p>
 
-      <h3 class="utility-h3">Use of the product</h3>
-      <p>
-        <span class="utility-highlighted">Join</span> is intended to be used for lawful purposes only, in accordance
-        with all applicable laws and regulations. Any use of <span class="utility-highlighted">Join</span> for illegal
-        activities, or to harass, harm, threaten, or intimidate another person, is strictly prohibited. You are solely
-        responsible for your interactions with other users of
-        <span class="utility-highlighted">Join</span>.
-      </p>
+        <h3 class="utility-h3">Use of the product</h3>
+        <p>
+          <span class="utility-highlighted">Join</span> is intended to be used for lawful purposes only, in accordance with all applicable laws and regulations. Any use of <span class="utility-highlighted">Join</span> for illegal activities, or to harass, harm, threaten, or intimidate another person, is strictly prohibited. You are solely responsible for your interactions with other users of
+          <span class="utility-highlighted">Join</span>.
+        </p>
 
-      <h3 class="utility-h3">Disclaimer of warranties and limitation of liability</h3>
-      <p>
-        <span class="utility-highlighted">Join</span> is provided "as is" without warranty of any kind, whether express
-        or implied, including but not limited to the implied warranties of merchantability, fitness for a particular
-        purpose, and non-infringement. In no event will we, the listed students, or the <span
-          class="utility-highlighted">Developer Akademie</span>, be liable for any direct,
-        indirect, incidental, special, consequential or exemplary damages, including but not limited to, damages for
-        loss of profits, goodwill, use, data, or other intangible losses, even if we have been advised of the
-        possibility of such damages, arising out of or in connection with the use or performance of <span
-          class="utility-highlighted">Join</span>.
-      </p>
+        <h3 class="utility-h3">Disclaimer of warranties and limitation of liability</h3>
+        <p>
+          <span class="utility-highlighted">Join</span> is provided "as is" without warranty of any kind, whether express or implied, including but not limited to the implied warranties of merchantability, fitness for a particular purpose, and non-infringement. In no event will we, the listed students, or the <span class="utility-highlighted">Developer Akademie</span>, be liable for any direct,
+          indirect, incidental, special, consequential or exemplary damages, including but not limited to, damages for loss of profits, goodwill, use, data, or other intangible losses, even if we have been advised of the possibility of such damages, arising out of or in connection with the use or performance of <span class="utility-highlighted">Join</span>.
+        </p>
 
-      <h3 class="utility-h3">Indemnity</h3>
-      <p>
-        You agree to indemnify, defend and hold harmless us, the listed students, the Developer Akademie, and our
-        affiliates, partners, officers, directors, agents, and employees, from and against any claim, demand, loss,
-        damage, cost, or liability (including reasonable legal fees) arising out of or relating to your use of <span
-          class="utility-highlighted">Join</span> and/or your breach of this
-        Legal Notice.
-      </p>
+        <h3 class="utility-h3">Indemnity</h3>
+        <p>
+          You agree to indemnify, defend and hold harmless us, the listed students, the Developer Akademie, and our affiliates, partners, officers, directors, agents, and employees, from and against any claim, demand, loss, damage, cost, or liability (including reasonable legal fees) arising out of or relating to your use of <span class="utility-highlighted">Join</span> and/or your breach of this
+          Legal Notice.
+        </p>
 
-      <p>For any questions or notices, please contact us at <a class="utility-highlighted"
-          href="mailto: Max@lm-lehner.at">Max@lm-lehner.at</a></p>
-      <br />
-      <p>Date: April 10, 2026</p>
-      <br />
+        <p>For any questions or notices, please contact us at <a class="utility-highlighted" href="mailto: Max@lm-lehner.at">Max@lm-lehner.at</a></p>
+        <br />
+        <p>Date: April 10, 2026</p>
+        <br />
 
-      <p>Quelle: <a href="https://www.e-recht24.de">https://www.e-recht24.de</a></p>
-    </section>
-  </main>
-</body>
-
+        <p>Quelle: <a href="https://www.e-recht24.de">https://www.e-recht24.de</a></p>
+      </section>
+    </main>
+  </body>
 </html>


### PR DESCRIPTION
Changed the title of the legal notice site to the correct English name, from "impressum" to "legal notice." Also checked the semantics on the site and changed the h1 element to an h2 element. On this HTML site, that there is only one h1 element. 